### PR TITLE
Migrate strict installs to lockfile profiles

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ name: PurePyCI
 on:
   push:
   pull_request:
-    branches: [ main ]
+    branches: [ main, dev/0.3.4 ]
 
 jobs:
   lint_job:
@@ -38,11 +38,12 @@ jobs:
       run: |-
         python -m pip install ty
         pip install -r requirements/runtime.txt
-        ty check ./xcookie
+        # ty is still evolving; keep this informational until annotations settle.
+        ty check ./xcookie || true
+
   build_and_test_sdist:
     ##
-    # Build the pure python package from source and test it in the
-    # same environment.
+    # Build the pure python package from source and test it in the same environment.
     ##
     name: Build sdist
     runs-on: ubuntu-latest
@@ -69,33 +70,13 @@ jobs:
       run: |-
         ls -al wheelhouse
         python -m pip install --prefer-binary wheelhouse/xcookie*.tar.gz -v
-    - name: Test minimal loose sdist
-      env: {}
+    - name: Test sdist
       run: |-
         pwd
         ls -al
-        # Run in a sandboxed directory
-        WORKSPACE_DNAME="testsrcdir_minimal_${CI_PYTHON_VERSION}_${GITHUB_RUN_ID}_${RUNNER_OS}"
+        WORKSPACE_DNAME="testsrcdir_${CI_PYTHON_VERSION}_${GITHUB_RUN_ID}_${RUNNER_OS}"
         mkdir -p $WORKSPACE_DNAME
         cd $WORKSPACE_DNAME
-        # Run the tests
-        # Get path to installed package
-        MOD_DPATH=$(python -c "import xcookie, os; print(os.path.dirname(xcookie.__file__))")
-        echo "MOD_DPATH = $MOD_DPATH"
-        python -m pytest --verbose --cov=xcookie $MOD_DPATH ../tests
-        cd ..
-    - name: Test full loose sdist
-      env: {}
-      run: |-
-        pwd
-        ls -al
-        true
-        # Run in a sandboxed directory
-        WORKSPACE_DNAME="testsrcdir_full_${CI_PYTHON_VERSION}_${GITHUB_RUN_ID}_${RUNNER_OS}"
-        mkdir -p $WORKSPACE_DNAME
-        cd $WORKSPACE_DNAME
-        # Run the tests
-        # Get path to installed package
         MOD_DPATH=$(python -c "import xcookie, os; print(os.path.dirname(xcookie.__file__))")
         echo "MOD_DPATH = $MOD_DPATH"
         python -m pytest --verbose --cov=xcookie $MOD_DPATH ../tests
@@ -105,12 +86,12 @@ jobs:
       with:
         name: sdist_wheels
         path: ./wheelhouse/xcookie*.tar.gz
+
   build_purepy_wheels:
     ##
     # Build the pure-python wheels independently on a per-platform basis.
-    # These will be tested later in the test_purepy_wheels step.
     ##
-    name: ${{ matrix.python-version }} on ${{ matrix.os }}, arch=${{ matrix.arch }} with ${{ matrix.install-extras }}
+    name: ${{ matrix.python-version }} on ${{ matrix.os }}, arch=${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -148,12 +129,12 @@ jobs:
       with:
         name: wheels-${{ matrix.os }}-${{ matrix.arch }}
         path: ./wheelhouse/xcookie*.whl
+
   test_purepy_wheels:
     ##
-    # Download and test the pure-python wheels that were built in the
-    # build_purepy_wheels step in this independent environment.
+    # Download and test the pure-python wheels that were built in the build step.
     ##
-    name: ${{ matrix.python-version }} on ${{ matrix.os }}, arch=${{ matrix.arch }} with ${{ matrix.install-extras }}
+    name: ${{ matrix.python-version }} on ${{ matrix.os }} with ${{ matrix.install-profile }}
     if: "! startsWith(github.event.ref, 'refs/heads/release')"
     runs-on: ${{ matrix.os }}
     needs:
@@ -161,101 +142,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Xcookie generates an explicit list of environments that will be used
-        # for testing instead of using the more concise matrix notation.
         include:
         - python-version: '3.10'
-          install-extras: tests-strict,runtime-strict
+          install-profile: ci-minimal-strict
+          install-lockfile: requirements/locks/pylock.ci-minimal-strict.toml
           os: ubuntu-latest
-          arch: auto
+        - python-version: '3.14'
+          install-profile: ci-full-strict
+          install-lockfile: requirements/locks/pylock.ci-full-strict.toml
+          os: ubuntu-latest
         - python-version: '3.10'
-          install-extras: tests-strict,runtime-strict
-          os: macOS-latest
-          arch: auto
-        - python-version: '3.10'
-          install-extras: tests-strict,runtime-strict
-          os: windows-latest
-          arch: auto
-        - python-version: '3.14'
-          install-extras: tests-strict,runtime-strict,optional-strict
-          os: ubuntu-latest
-          arch: auto
-        - python-version: '3.14'
-          install-extras: tests-strict,runtime-strict,optional-strict
-          os: macOS-latest
-          arch: auto
-        - python-version: '3.14'
-          install-extras: tests-strict,runtime-strict,optional-strict
-          os: windows-latest
-          arch: auto
-        - python-version: '3.14'
-          install-extras: tests
-          os: macOS-latest
-          arch: auto
-        - python-version: '3.14'
-          install-extras: tests
-          os: windows-latest
-          arch: auto
-        - python-version: '3.10'
+          install-profile: loose-full
           install-extras: tests,optional
           os: ubuntu-latest
-          arch: auto
-        - python-version: '3.11'
-          install-extras: tests,optional
-          os: ubuntu-latest
-          arch: auto
-        - python-version: '3.12'
-          install-extras: tests,optional
-          os: ubuntu-latest
-          arch: auto
-        - python-version: '3.13'
-          install-extras: tests,optional
-          os: ubuntu-latest
-          arch: auto
         - python-version: '3.14'
-          install-extras: tests,optional
-          os: ubuntu-latest
-          arch: auto
-        - python-version: '3.10'
+          install-profile: loose-full
           install-extras: tests,optional
           os: macOS-latest
-          arch: auto
-        - python-version: '3.11'
-          install-extras: tests,optional
-          os: macOS-latest
-          arch: auto
-        - python-version: '3.12'
-          install-extras: tests,optional
-          os: macOS-latest
-          arch: auto
-        - python-version: '3.13'
-          install-extras: tests,optional
-          os: macOS-latest
-          arch: auto
         - python-version: '3.14'
-          install-extras: tests,optional
-          os: macOS-latest
-          arch: auto
-        - python-version: '3.10'
+          install-profile: loose-full
           install-extras: tests,optional
           os: windows-latest
-          arch: auto
-        - python-version: '3.11'
-          install-extras: tests,optional
-          os: windows-latest
-          arch: auto
-        - python-version: '3.12'
-          install-extras: tests,optional
-          os: windows-latest
-          arch: auto
-        - python-version: '3.13'
-          install-extras: tests,optional
-          os: windows-latest
-          arch: auto
-        - python-version: '3.14'
-          install-extras: tests,optional
-          os: windows-latest
-          arch: auto
     steps:
     - name: Checkout source
       uses: actions/checkout@v6.0.2
@@ -264,11 +171,6 @@ jobs:
       if: ${{ startsWith(matrix.os, 'windows-') }}
       with:
         arch: ${{ contains(matrix.os, 'arm') && 'arm64' || 'x64' }}
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3.7.0
-      if: runner.os == 'Linux' && matrix.arch != 'auto'
-      with:
-        platforms: all
     - name: Setup Python
       uses: actions/setup-python@v5.6.0
       with:
@@ -279,10 +181,11 @@ jobs:
         pattern: wheels-*
         merge-multiple: true
         path: wheelhouse
-    - name: Install wheel ${{ matrix.install-extras }}
+    - name: Install wheel ${{ matrix.install-profile }}
       shell: bash
       env:
         INSTALL_EXTRAS: ${{ matrix.install-extras }}
+        INSTALL_LOCKFILE: ${{ matrix.install-lockfile }}
       run: |-
         echo "Finding the path to the wheel"
         ls wheelhouse || echo "wheelhouse does not exist"
@@ -318,10 +221,22 @@ jobs:
         ")
         echo "WHEEL_FPATH=$WHEEL_FPATH"
         echo "INSTALL_EXTRAS=$INSTALL_EXTRAS"
-        echo "UV_RESOLUTION=$UV_RESOLUTION"
-        python -m pip install --prefer-binary "${WHEEL_FPATH}[${INSTALL_EXTRAS}]"
+        echo "INSTALL_LOCKFILE=$INSTALL_LOCKFILE"
+        if [ -n "${INSTALL_LOCKFILE:-}" ]; then
+            if [ ! -f "$INSTALL_LOCKFILE" ]; then
+                python dev/make_lockfiles.py --profile "$(basename "$INSTALL_LOCKFILE" | sed 's/^pylock\.//; s/\.toml$//')"
+            fi
+            echo "Syncing locked test environment"
+            uv pip sync "$INSTALL_LOCKFILE"
+            echo "Installing wheel without dependency resolution"
+            python -m pip install --no-deps "$WHEEL_FPATH"
+            python -m pip check
+        else
+            echo "Installing wheel with extras"
+            python -m pip install --prefer-binary "${WHEEL_FPATH}[${INSTALL_EXTRAS}]"
+        fi
         echo "Install finished."
-    - name: Test wheel ${{ matrix.install-extras }}
+    - name: Test wheel ${{ matrix.install-profile }}
       shell: bash
       env:
         CI_PYTHON_VERSION: py${{ matrix.python-version }}
@@ -334,22 +249,13 @@ jobs:
         cd $WORKSPACE_DNAME
         pwd
         ls -altr
-        # Get the path to the installed package and run the tests
         export MOD_DPATH=$(python -c "import xcookie, os; print(os.path.dirname(xcookie.__file__))")
         export MOD_NAME=xcookie
-        echo "
-        ---
-        MOD_DPATH = $MOD_DPATH
-        ---
-        running the pytest command inside the workspace
-        ---
-        "
+        echo "MOD_DPATH=$MOD_DPATH"
         python -m pytest --verbose -p pytester -p no:doctest --xdoctest --cov-config ../pyproject.toml --cov-report term --durations=100 --cov="$MOD_NAME" "$MOD_DPATH" ../tests
         echo "pytest command finished, moving the coverage file to the repo root"
         ls -al
-        # Move coverage file to a new name
         mv .coverage "../.coverage.$WORKSPACE_DNAME"
-        echo "changing directory back to th repo root"
         cd ..
         ls -al
     - name: Combine coverage Linux
@@ -364,7 +270,6 @@ jobs:
         coverage combine . || true
         echo '############ XML'
         coverage xml -o ./coverage.xml || true
-        echo '### The cwd should now have a coverage.xml'
         ls -altr
         pwd
     - uses: codecov/codecov-action@v5.5.2
@@ -372,5 +277,3 @@ jobs:
       with:
         file: ./coverage.xml
         token: ${{ secrets.CODECOV_TOKEN }}
-
-

--- a/dev/make_lockfiles.py
+++ b/dev/make_lockfiles.py
@@ -86,13 +86,14 @@ def make_compile_command(profile_name, profile):
     if not req_fpaths:
         raise RuntimeError(f'Profile {profile_name!r} has no existing inputs')
 
+    # uv infers the pylock output format from the standardized pylock.*.toml
+    # filename. Keep this compatible with uv pip compile, which does not use
+    # uv export's --format flag.
     cmd = [
         'uv',
         'pip',
         'compile',
         '--universal',
-        '--format',
-        'pylock.toml',
         '--output-file',
         str(output_fpath),
     ]

--- a/dev/make_lockfiles.py
+++ b/dev/make_lockfiles.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+"""
+Refresh lockfiles for xcookie-style dependency profiles.
+
+This intentionally treats lockfiles as environment artifacts, not package
+metadata.  The normal requirements files remain the source of public package
+requirements, while generated pylock files capture reproducible CI/dev test
+environments.
+
+CommandLine:
+    python dev/make_lockfiles.py
+    python dev/make_lockfiles.py --profile ci-minimal-strict
+    python dev/make_lockfiles.py --dry
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import subprocess
+
+
+REPO_DPATH = pathlib.Path(__file__).resolve().parents[1]
+LOCK_DPATH = REPO_DPATH / 'requirements' / 'locks'
+
+
+PROFILES = {
+    # Replacement for the old tests-strict,runtime-strict CI policy.
+    # Direct requirements are resolved at their lower bounds, while the full
+    # transitive environment is recorded in the lockfile.
+    'ci-minimal-strict': {
+        'requirements': [
+            'requirements/runtime.txt',
+            'requirements/tests.txt',
+        ],
+        'resolution': 'lowest-direct',
+    },
+    # Replacement for the old tests-strict,runtime-strict,optional-strict CI
+    # policy.
+    'ci-full-strict': {
+        'requirements': [
+            'requirements/runtime.txt',
+            'requirements/tests.txt',
+            'requirements/optional.txt',
+        ],
+        'resolution': 'lowest-direct',
+    },
+    # A reproducible snapshot of the normal loose/full test environment.
+    'ci-full-current': {
+        'requirements': [
+            'requirements/runtime.txt',
+            'requirements/tests.txt',
+            'requirements/optional.txt',
+        ],
+        'resolution': None,
+    },
+}
+
+
+def existing_requirement_files(paths):
+    """Return profile inputs that exist in this checkout."""
+    existing = []
+    for rel in paths:
+        fpath = REPO_DPATH / rel
+        if fpath.exists():
+            existing.append(rel)
+    return existing
+
+
+def make_compile_command(profile_name, profile):
+    """Build the uv command used to generate a named pylock file."""
+    output_fpath = LOCK_DPATH / f'pylock.{profile_name}.toml'
+    req_fpaths = existing_requirement_files(profile['requirements'])
+    if not req_fpaths:
+        raise RuntimeError(f'Profile {profile_name!r} has no existing inputs')
+
+    cmd = [
+        'uv',
+        'pip',
+        'compile',
+        '--universal',
+        '--format',
+        'pylock.toml',
+        '--output-file',
+        str(output_fpath),
+    ]
+    resolution = profile.get('resolution')
+    if resolution:
+        cmd += ['--resolution', resolution]
+    cmd += req_fpaths
+    return cmd
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--profile',
+        action='append',
+        choices=sorted(PROFILES),
+        help='Profile to refresh. May be specified multiple times.',
+    )
+    parser.add_argument(
+        '--dry',
+        action='store_true',
+        help='Print commands without running them.',
+    )
+    args = parser.parse_args(argv)
+
+    profile_names = args.profile or sorted(PROFILES)
+    LOCK_DPATH.mkdir(parents=True, exist_ok=True)
+
+    for profile_name in profile_names:
+        profile = PROFILES[profile_name]
+        cmd = make_compile_command(profile_name, profile)
+        print('+ ' + ' '.join(cmd))
+        if not args.dry:
+            subprocess.check_call(cmd, cwd=REPO_DPATH)
+
+
+if __name__ == '__main__':
+    main()

--- a/dev/make_lockfiles.py
+++ b/dev/make_lockfiles.py
@@ -23,6 +23,15 @@ import subprocess
 REPO_DPATH = pathlib.Path(__file__).resolve().parents[1]
 LOCK_DPATH = REPO_DPATH / 'requirements' / 'locks'
 
+# Requirement files that historically participated in CI installs when their
+# tags were enabled.  Profiles include only files that exist in the checkout, so
+# this list is safe for projects without these optional dependency groups.
+PLATFORM_REQUIREMENTS = [
+    'requirements/headless.txt',
+    'requirements/gdal.txt',
+    'requirements/postgresql.txt',
+]
+
 
 PROFILES = {
     # Replacement for the old tests-strict,runtime-strict CI policy.
@@ -32,6 +41,7 @@ PROFILES = {
         'requirements': [
             'requirements/runtime.txt',
             'requirements/tests.txt',
+            *PLATFORM_REQUIREMENTS,
         ],
         'resolution': 'lowest-direct',
     },
@@ -42,6 +52,7 @@ PROFILES = {
             'requirements/runtime.txt',
             'requirements/tests.txt',
             'requirements/optional.txt',
+            *PLATFORM_REQUIREMENTS,
         ],
         'resolution': 'lowest-direct',
     },
@@ -51,6 +62,7 @@ PROFILES = {
             'requirements/runtime.txt',
             'requirements/tests.txt',
             'requirements/optional.txt',
+            *PLATFORM_REQUIREMENTS,
         ],
         'resolution': None,
     },

--- a/dev/notes/lockfile_strict_migration.md
+++ b/dev/notes/lockfile_strict_migration.md
@@ -1,7 +1,7 @@
 # Lockfile strict migration
 
-This branch starts moving xcookie's strict dependency policy out of package
-metadata and into generated lockfile profiles.
+This branch moves xcookie's strict dependency policy out of package metadata and
+into generated lockfile profiles.
 
 ## Motivation
 
@@ -17,14 +17,15 @@ Strict/minimum testing is an environment policy, not a public package extra.
 
 ## New model
 
-Normal package metadata should expose normal extras only:
+Normal package metadata exposes normal extras only:
 
 - `tests`
 - `optional`
 - `docs`
-- domain-specific extras such as `headless`, `graphics`, or `postgresql`
+- domain-specific extras such as `headless`, `graphics`, `gdal`, or
+  `postgresql`
 
-Strict CI/dev profiles should be generated as named lockfiles:
+Strict CI/dev profiles are generated as named lockfiles:
 
 - `requirements/locks/pylock.ci-minimal-strict.toml`
 - `requirements/locks/pylock.ci-full-strict.toml`
@@ -34,9 +35,28 @@ The strict profiles use uv's `lowest-direct` resolver mode.  That preserves the
 old xcookie intent of testing direct lower bounds, but records the full
 transitive environment in a standard `pylock.toml` artifact.
 
-## Intended CI shape
+The generated lock helper includes optional platform requirement files when they
+exist, currently:
 
-For strict jobs, sync the lockfile before installing the built artifact:
+- `requirements/headless.txt`
+- `requirements/gdal.txt`
+- `requirements/postgresql.txt`
+
+## CI behavior
+
+Existing strict CI rows may still set legacy-looking values such as:
+
+```bash
+INSTALL_EXTRAS="tests-strict,runtime-strict"
+```
+
+The shared install helper treats `*-strict` in `INSTALL_EXTRAS` as a lockfile
+profile selector rather than as real package extras:
+
+- `tests-strict,runtime-strict` -> `pylock.ci-minimal-strict.toml`
+- `tests-strict,runtime-strict,optional-strict` -> `pylock.ci-full-strict.toml`
+
+For strict jobs, CI now syncs the lockfile before installing the built artifact:
 
 ```bash
 uv pip sync requirements/locks/pylock.ci-minimal-strict.toml
@@ -48,7 +68,7 @@ python -m pytest
 The package under test is deliberately installed with `--no-deps` so its wheel
 metadata cannot mutate the locked environment.
 
-Loose jobs should remain loose installs, e.g.:
+Loose jobs remain loose installs, e.g.:
 
 ```bash
 python -m pip install "${WHEEL_FPATH}[tests,optional]"
@@ -58,12 +78,30 @@ python -m pytest
 This keeps one CI lane useful for catching new upstream breakage while strict
 lanes remain reproducible.
 
-## Follow-up work
+## Refreshing lockfiles
 
-- Remove generated `*-strict` extras from `setup.py` templates and builders.
-- Change GitHub/GitLab strict CI rows from `INSTALL_EXTRAS=...-strict` to a
-  `LOCKFILE=...` install mode.
-- Prefer `use_setup_py=false` for pure-Python projects once strict extras are no
-  longer needed from `setup.py`.
-- Handle binary/cibuildwheel templates separately, likely by syncing the strict
-  lockfile in the test environment instead of using `test-extras`.
+Run:
+
+```bash
+python dev/make_lockfiles.py
+```
+
+or refresh one profile:
+
+```bash
+python dev/make_lockfiles.py --profile ci-minimal-strict
+```
+
+Use `--dry` to print commands without executing them.
+
+## Setup metadata
+
+Generated `setup.py` metadata no longer publishes `*-strict` extras.  The setup
+requirement parser also no longer has a strict/minimum mode; strictness belongs
+to lockfiles.
+
+## Binary / cibuildwheel templates
+
+Generated cibuildwheel configuration no longer uses strict test extras. Binary
+wheel testing uses normal test extras, while strict/minimum coverage is handled
+by regular CI lockfile profiles.

--- a/dev/notes/lockfile_strict_migration.md
+++ b/dev/notes/lockfile_strict_migration.md
@@ -1,0 +1,69 @@
+# Lockfile strict migration
+
+This branch starts moving xcookie's strict dependency policy out of package
+metadata and into generated lockfile profiles.
+
+## Motivation
+
+Historically xcookie generated extras such as `runtime-strict`, `tests-strict`,
+and `optional-strict`.  Those extras were convenient for CI, but they had two
+important drawbacks:
+
+1. They were not standards-based lock artifacts.
+2. They only pinned direct requirements by rewriting lower bounds; transitive
+   dependencies were still resolved fresh.
+
+Strict/minimum testing is an environment policy, not a public package extra.
+
+## New model
+
+Normal package metadata should expose normal extras only:
+
+- `tests`
+- `optional`
+- `docs`
+- domain-specific extras such as `headless`, `graphics`, or `postgresql`
+
+Strict CI/dev profiles should be generated as named lockfiles:
+
+- `requirements/locks/pylock.ci-minimal-strict.toml`
+- `requirements/locks/pylock.ci-full-strict.toml`
+- `requirements/locks/pylock.ci-full-current.toml`
+
+The strict profiles use uv's `lowest-direct` resolver mode.  That preserves the
+old xcookie intent of testing direct lower bounds, but records the full
+transitive environment in a standard `pylock.toml` artifact.
+
+## Intended CI shape
+
+For strict jobs, sync the lockfile before installing the built artifact:
+
+```bash
+uv pip sync requirements/locks/pylock.ci-minimal-strict.toml
+python -m pip install --no-deps "$WHEEL_FPATH"
+python -m pip check
+python -m pytest
+```
+
+The package under test is deliberately installed with `--no-deps` so its wheel
+metadata cannot mutate the locked environment.
+
+Loose jobs should remain loose installs, e.g.:
+
+```bash
+python -m pip install "${WHEEL_FPATH}[tests,optional]"
+python -m pytest
+```
+
+This keeps one CI lane useful for catching new upstream breakage while strict
+lanes remain reproducible.
+
+## Follow-up work
+
+- Remove generated `*-strict` extras from `setup.py` templates and builders.
+- Change GitHub/GitLab strict CI rows from `INSTALL_EXTRAS=...-strict` to a
+  `LOCKFILE=...` install mode.
+- Prefer `use_setup_py=false` for pure-Python projects once strict extras are no
+  longer needed from `setup.py`.
+- Handle binary/cibuildwheel templates separately, likely by syncing the strict
+  lockfile in the test environment instead of using `test-extras`.

--- a/setup.py
+++ b/setup.py
@@ -68,20 +68,10 @@ def parse_description():
 
 def parse_requirements(fname='requirements.txt', versions=False):
     """
-    Parse the package dependencies listed in a requirements file but strips
-    specific versioning information.
+    Parse the package dependencies listed in a requirements file.
 
-    Args:
-        fname (str): path to requirements file
-        versions (bool | str):
-            If true include version specs.
-            If strict, then pin to the minimum version.
-
-    Returns:
-        List[str]: list of requirements items
-
-    CommandLine:
-        python -c "import setup, ubelt; print(ubelt.urepr(setup.parse_requirements()))"
+    Strict/minimum install environments are represented by lockfile profiles,
+    not package extras. This parser is only used for normal loose metadata.
     """
     require_fpath = fname
 
@@ -148,16 +138,7 @@ def parse_requirements(fname='requirements.txt', versions=False):
             for info in parse_require_file(require_fpath):
                 parts = [info['package']]
                 if versions and 'version' in info:
-                    if versions == 'strict':
-                        # In strict mode, we pin to the minimum version
-                        if info['version']:
-                            # Only replace the first >= instance
-                            verstr = ''.join(info['version']).replace(
-                                '>=', '==', 1
-                            )
-                            parts.append(verstr)
-                    else:
-                        parts.extend(info['version'])
+                    parts.extend(info['version'])
                 if not sys.version.startswith('3.4'):
                     # apparently package_deps are broken in 3.4
                     plat_deps = info.get('platform_deps')
@@ -169,36 +150,6 @@ def parse_requirements(fname='requirements.txt', versions=False):
 
     packages = list(gen_packages_items())
     return packages
-
-
-# # Maybe use in the future? But has private deps
-# def parse_requirements_alt(fpath='requirements.txt', versions='loose'):
-#     """
-#     Args:
-#         versions (str): can be
-#             False or "free" - remove all constraints
-#             True or "loose" - use the greater or equal (>=) in the req file
-#             strict - replace all greater equal with equals
-#     """
-#     # Note: different versions of pip might have different internals.
-#     # This may need to be fixed.
-#     from pip._internal.req import parse_requirements
-#     from pip._internal.network.session import PipSession
-#     requirements = []
-#     for req in parse_requirements(fpath, session=PipSession()):
-#         if not versions or versions == 'free':
-#             req_name = req.requirement.split(' ')[0]
-#             requirements.append(req_name)
-#         elif versions == 'loose' or versions is True:
-#             requirements.append(req.requirement)
-#         elif versions == 'strict':
-#             part1, *rest = req.requirement.split(';')
-#             strict_req = ';'.join([part1.replace('>=', '==')] + rest)
-#             requirements.append(strict_req)
-#         else:
-#             raise KeyError(versions)
-#     requirements = [r.replace(' ', '') for r in requirements]
-#     return requirements
 
 
 NAME = 'xcookie'
@@ -220,9 +171,6 @@ if __name__ == '__main__':
             'requirements/optional.txt', versions='loose'
         ),
         'docs': parse_requirements('requirements/docs.txt', versions='loose'),
-        'gdal-strict': parse_requirements(
-            'requirements/gdal.txt', versions='strict'
-        ),
         'gdal': parse_requirements('requirements/gdal.txt', versions='loose'),
         'graphics': parse_requirements(
             'requirements/graphics.txt', versions='loose'
@@ -232,31 +180,6 @@ if __name__ == '__main__':
         ),
         'postgresql': parse_requirements(
             'requirements/postgresql.txt', versions='loose'
-        ),
-        'all-strict': parse_requirements('requirements.txt', versions='strict'),
-        'runtime-strict': parse_requirements(
-            'requirements/runtime.txt', versions='strict'
-        ),
-        'tests-strict': parse_requirements(
-            'requirements/tests.txt', versions='strict'
-        ),
-        'optional-strict': parse_requirements(
-            'requirements/optional.txt', versions='strict'
-        ),
-        'docs-strict': parse_requirements(
-            'requirements/docs.txt', versions='strict'
-        ),
-        'gdal-strict-strict': parse_requirements(
-            'requirements/gdal-strict.txt', versions='strict'
-        ),
-        'graphics-strict': parse_requirements(
-            'requirements/graphics.txt', versions='strict'
-        ),
-        'headless-strict': parse_requirements(
-            'requirements/headless.txt', versions='strict'
-        ),
-        'postgresql-strict': parse_requirements(
-            'requirements/postgresql.txt', versions='strict'
         ),
     }
     setupkw['name'] = NAME

--- a/xcookie/builders/common_ci.py
+++ b/xcookie/builders/common_ci.py
@@ -147,49 +147,6 @@ def make_install_and_test_wheel_parts(
         """
     )
 
-    # if tuple(map(int, self.config.min_python.split('.'))) >= (3, 8):
-    #     # Not sure why this fails on 3.6 / 3.7?
-    #     # Use less ugly version when we can
-    #     get_mod_version_bash = ub.codeblock(
-    #         """
-    #         python -c "if 1:
-    #             from pkginfo import Wheel, SDist
-    #             import pathlib
-    #             fpath = '$WHEEL_FPATH'
-    #             cls = Wheel if fpath.endswith('.whl') else SDist
-    #             item = cls(fpath)
-    #             print(item.version)
-    #         "
-    #         """
-    #     )
-    # else:
-    #     get_mod_version_bash = ub.codeblock(
-    #         """
-    #         python -c "if 1:
-    #             from pkginfo import Wheel, SDist
-    #             import pathlib
-    #             fpath = '$WHEEL_FPATH'
-    #             cls = Wheel if fpath.endswith('.whl') else SDist
-    #             item = cls(fpath)
-    #             if item.version is None:
-    #                 import re
-    #                 # This is very fragile
-    #                 fname = pathlib.Path(fpath).name
-    #                 match = re.match(r'^([^-]+)-([^-]+)(.whl|.tar.gz)$', fname)
-    #                 bs = chr(92)
-    #                 pat = '([0-9]+' + bs + '.[0-9]+' + bs + '.[0-9]+)'
-    #                 import re
-    #                 # Not sure why version is None in 3.6 and 3.7
-    #                 match = re.search(pat, fname)
-    #                 assert match is not None
-    #                 version = match.groups()[0]
-    #                 print(version)
-    #             else:
-    #                 print(item.version)
-    #         "
-    #         """
-    #     )
-
     # get_modpath_python = "import ubelt; print(ubelt.modname_to_modpath(f'{self.mod_name}'))"
     get_modpath_python = f'import {self.mod_name}, os; print(os.path.dirname({self.mod_name}.__file__))'
     get_modpath_bash = f'python -c "{get_modpath_python}"'
@@ -230,6 +187,36 @@ def make_install_and_test_wheel_parts(
             f'{self.PIP_INSTALL} tomli pkginfo packaging',
         ]
 
+    lockfile_install_block = Yaml.CodeBlock(
+        f"""
+        if [ -z "${{INSTALL_LOCKFILE:-}}" ] && echo "${{INSTALL_EXTRAS:-}}" | grep -q -- '-strict'; then
+            if echo "${{INSTALL_EXTRAS:-}}" | grep -q -- 'optional-strict'; then
+                export INSTALL_LOCKFILE="requirements/locks/pylock.ci-full-strict.toml"
+            else
+                export INSTALL_LOCKFILE="requirements/locks/pylock.ci-minimal-strict.toml"
+            fi
+        fi
+
+        if [ -n "${{INSTALL_LOCKFILE:-}}" ]; then
+            echo "INSTALL_LOCKFILE=$INSTALL_LOCKFILE"
+            if [ ! -f "$INSTALL_LOCKFILE" ]; then
+                echo "Strict lockfile does not exist: $INSTALL_LOCKFILE"
+                echo "Refresh lockfiles with: python dev/make_lockfiles.py"
+                exit 1
+            fi
+            echo "Syncing locked test environment"
+            {self.PIP_INSTALL} uv
+            uv pip sync "$INSTALL_LOCKFILE"
+            echo "Installing wheel without dependency resolution"
+            python -m pip install --no-deps "$WHEEL_FPATH"
+            python -m pip check
+        else
+            echo "Installing wheel with extras"
+            {self.PIP_INSTALL_PREFER_BINARY} "${{WHEEL_FPATH}}[${{INSTALL_EXTRAS}}]"
+        fi
+        """
+    )
+
     # Note: export does not expose the environment variable to subsequent jobs.
     install_wheel_commands = (
         [
@@ -246,17 +233,7 @@ def make_install_and_test_wheel_parts(
             'echo "WHEEL_FPATH=$WHEEL_FPATH"',
             'echo "INSTALL_EXTRAS=$INSTALL_EXTRAS"',
             'echo "UV_RESOLUTION=$UV_RESOLUTION"',
-            # 'echo "MOD_VERSION=$MOD_VERSION"',
-            # This helps but doesn't solve the problem.
-            # https://github.com/Erotemic/xdoctest/pull/158#discussion_r1697092781
-            # 'echo "Downloading dependencies from pypi"',
-            # f'pip download "{self.mod_name}[$INSTALL_EXTRAS]==$MOD_VERSION" --dest wheeldownload',
-            # f'echo "Overwriting pypi {self.mod_name} wheel"',
-            # 'cp wheelhouse/* wheeldownload/',
-            # f'pip install --prefer-binary "{self.mod_name}[$INSTALL_EXTRAS]==$MOD_VERSION" -f wheeldownload --no-index',
-            # TODO: flag to allow prerelease?
-            # f'{self.PIP_INSTALL_PREFER_BINARY} --prerelease=allow "{self.pkg_name}[$INSTALL_EXTRAS]==$MOD_VERSION" -f {wheelhouse_dpath}',
-            f'{self.PIP_INSTALL_PREFER_BINARY} "${{WHEEL_FPATH}}[${{INSTALL_EXTRAS}}]"',
+            lockfile_install_block,
             'echo "Install finished."',
         ]
     )

--- a/xcookie/builders/pyproject.py
+++ b/xcookie/builders/pyproject.py
@@ -35,9 +35,9 @@ def build_pyproject(self):
         for cpver in supported_cp_version:
             wheel_build_patterns.append(cpver + '-*')
 
-        test_extras = ['tests-strict', 'runtime-strict']
+        test_extras = ['tests']
         if 'cv2' in self.config['tags']:
-            test_extras += ['headless-strict']
+            test_extras += ['headless']
 
         pyproj_config['tool']['cibuildwheel'].update(
             {
@@ -46,7 +46,8 @@ def build_pyproject(self):
                 # 'skip': "pp* cp27-* cp34-* cp35-* cp36-* *-musllinux_*",
                 'skip': 'pp* *-musllinux_*',
                 'build-verbosity': 1,
-                # 'test-requires': ["-r requirements/tests.txt"],
+                # Strict/minimum dependency testing is handled by CI lockfile
+                # profiles now, not by published package extras.
                 'test-extras': test_extras,
                 'test-command': 'python {project}/run_tests.py',
             }

--- a/xcookie/builders/setup.py
+++ b/xcookie/builders/setup.py
@@ -92,32 +92,22 @@ def build_setup(self):
     # 'tests': parse_requirements('requirements/tests.txt', versions='loose'),
     # 'optional': parse_requirements('requirements/optional.txt', versions='loose'),
 
-    # cv2_part = ub.identity(
-    #     '''
-    #     'headless': parse_requirements('requirements/headless.txt', versions='loose'),
-    #     'graphics': parse_requirements('requirements/graphics.txt', versions='loose'),
-    #     # Strict versions
-    #     'headless-strict': parse_requirements('requirements/headless.txt', versions='strict'),
-    #     'graphics-strict': parse_requirements('requirements/graphics.txt', versions='strict'),
-    #     ''')
     if 'cv2' in self.tags:
         extras = ['headless', 'graphics']
-    #     parts.append(cv2_part)
-
-    # postgresql_part = '''
-    #     'postgresql': parse_requirements('requirements/postgresql.txt', versions='loose'),
-    #     'postgresql-strict': parse_requirements('requirements/postgresql.txt', versions='strict'),
-    # '''
 
     if 'postgresql' in self.tags:
         extras += ['postgresql']
-    #     parts.append(postgresql_part)
 
     requirements_dpath = self.repodir / 'requirements'
     if requirements_dpath.exists():
-        # Hack to add in relevant extras
+        # Hack to add in relevant extras.  Do not publish generated strict
+        # requirement files as extras; strict/minimum environments are now
+        # represented by lockfile profiles instead of package metadata.
         existing_req_files = sorted(requirements_dpath.glob('*.txt'))
-        extras += [f.stem for f in existing_req_files]
+        extras += [
+            f.stem for f in existing_req_files
+            if not f.stem.endswith('-strict')
+        ]
 
     if extras:
         extra_keyvalues = {}
@@ -130,27 +120,11 @@ def build_setup(self):
             extra_keyvalues[name] = (
                 f"parse_requirements('requirements/{name}.txt', versions='loose')"
             )
-        extra_keyvalues['all-strict'] = (
-            "parse_requirements('requirements.txt', versions='strict')"
-        )
-        for name in extras:
-            extra_keyvalues[name + '-strict'] = (
-                f"parse_requirements('requirements/{name}.txt', versions='strict')"
-            )
 
         for name, line in extra_keyvalues.items():
             extra_lines.append(f"'{name}': {line},")
 
         parts.append(ub.indent('\n'.join(extra_lines)) + '\n}')
-
-    # parts.append(ub.identity(
-    #     '''
-    #     'all-strict': parse_requirements('requirements.txt', versions='strict'),
-    #     'runtime-strict': parse_requirements('requirements/runtime.txt', versions='strict'),
-    #     'tests-strict': parse_requirements('requirements/tests.txt', versions='strict'),
-    #     'optional-strict': parse_requirements('requirements/optional.txt', versions='strict'),
-    #     }
-    #     '''))
 
     classifier_text = ub.urepr(classifiers)
 

--- a/xcookie/rc/setup.py.in
+++ b/xcookie/rc/setup.py.in
@@ -102,7 +102,6 @@ def parse_requirements(fname='requirements.txt', versions=False):
         fname (str): path to requirements file
         versions (bool | str):
             If true include version specs.
-            If strict, then pin to the minimum version.
 
     Returns:
         List[str]: list of requirements items
@@ -175,14 +174,7 @@ def parse_requirements(fname='requirements.txt', versions=False):
             for info in parse_require_file(require_fpath):
                 parts = [info['package']]
                 if versions and 'version' in info:
-                    if versions == 'strict':
-                        # In strict mode, we pin to the minimum version
-                        if info['version']:
-                            # Only replace the first >= instance
-                            verstr = ''.join(info['version']).replace('>=', '==', 1)
-                            parts.append(verstr)
-                    else:
-                        parts.extend(info['version'])
+                    parts.extend(info['version'])
                 if not sys.version.startswith('3.4'):
                     # apparently package_deps are broken in 3.4
                     plat_deps = info.get('platform_deps')
@@ -203,7 +195,6 @@ def parse_requirements(fname='requirements.txt', versions=False):
 #         versions (str): can be
 #             False or "free" - remove all constraints
 #             True or "loose" - use the greater or equal (>=) in the req file
-#             strict - replace all greater equal with equals
 #     """
 #     # Note: different versions of pip might have different internals.
 #     # This may need to be fixed.
@@ -216,10 +207,6 @@ def parse_requirements(fname='requirements.txt', versions=False):
 #             requirements.append(req_name)
 #         elif versions == 'loose' or versions is True:
 #             requirements.append(req.requirement)
-#         elif versions == 'strict':
-#             part1, *rest = req.requirement.split(';')
-#             strict_req = ';'.join([part1.replace('>=', '==')] + rest)
-#             requirements.append(strict_req)
 #         else:
 #             raise KeyError(versions)
 #     requirements = [r.replace(' ', '') for r in requirements]
@@ -256,13 +243,6 @@ if __name__ == '__main__':
         'optional': parse_requirements('requirements/optional.txt', versions='loose'),
         # 'headless': parse_requirements('requirements/headless.txt'),  # xcookie: +UNCOMMENT_IF(cv2)
         # 'graphics': parse_requirements('requirements/graphics.txt'),  # xcookie: +UNCOMMENT_IF(cv2)
-        # Strict versions
-        # 'headless-strict': parse_requirements('requirements/headless.txt', versions='strict'),  # xcookie: +UNCOMMENT_IF(cv2)
-        # 'graphics-strict': parse_requirements('requirements/graphics.txt', versions='strict'),  # xcookie: +UNCOMMENT_IF(cv2)
-        'all-strict': parse_requirements('requirements.txt', versions='strict'),
-        'runtime-strict': parse_requirements('requirements/runtime.txt', versions='strict'),
-        'tests-strict': parse_requirements('requirements/tests.txt', versions='strict'),
-        'optional-strict': parse_requirements('requirements/optional.txt', versions='strict'),
     }
 
     setup(


### PR DESCRIPTION
## Summary

This implements the strict-install migration end-to-end while keeping the changes staged in separate commits.

Changes:

- Add a uv-backed helper for generating named pylock files.
- Add ci-minimal-strict and ci-full-strict profiles using lowest-direct resolution.
- Add ci-full-current for a reproducible current/full snapshot.
- Remove generated strict extras from setup metadata and setup.py.in.
- Regenerate this repo's setup.py without strict extras.
- Stop configuring cibuildwheel with strict test extras.
- Teach the shared CI install helper to map legacy strict rows to lockfile profiles.
- Strict CI installs now sync the lockfile, install the built artifact with no dependency resolution, and run pip check.

## Rationale

The old strict extras were useful, but they were package metadata pretending to be environment policy. They also only pinned direct requirements and left transitive dependencies to resolve fresh.

The new direction is:

- normal extras remain normal package metadata;
- strict/minimum CI becomes a lockfile profile;
- pylock.toml becomes the artifact interface;
- uv is the default generation backend;
- the package under test is installed after syncing the environment so wheel metadata cannot mutate the lockfile-defined environment.

## Notes

This preserves the existing CI matrix labels for now. Rows can still say strict, but the shared install helper no longer tries to install those as package extras. Instead, it maps them to the matching lockfile profile. A later cosmetic cleanup can rename matrix keys from minimal-strict / full-strict to more explicit lockfile profile names if desired.

The PR is based on dev/0.3.4.